### PR TITLE
feat: scaffold estimating app

### DIFF
--- a/frontend-nextjs/app/tools/estimating-app/calculations/labor.js
+++ b/frontend-nextjs/app/tools/estimating-app/calculations/labor.js
@@ -1,0 +1,3 @@
+export function calculateLabor(hours, rate) {
+  return hours * rate;
+}

--- a/frontend-nextjs/app/tools/estimating-app/calculations/markup.js
+++ b/frontend-nextjs/app/tools/estimating-app/calculations/markup.js
@@ -1,0 +1,3 @@
+export function calculateMarkup(subtotal, percentage) {
+  return subtotal * (percentage / 100);
+}

--- a/frontend-nextjs/app/tools/estimating-app/calculations/material.js
+++ b/frontend-nextjs/app/tools/estimating-app/calculations/material.js
@@ -1,0 +1,3 @@
+export function calculateMaterial(quantity, unitCost) {
+  return quantity * unitCost;
+}

--- a/frontend-nextjs/app/tools/estimating-app/components/BidSummary.js
+++ b/frontend-nextjs/app/tools/estimating-app/components/BidSummary.js
@@ -1,0 +1,4 @@
+// Placeholder Bid summary component
+export default function BidSummary() {
+  return null;
+}

--- a/frontend-nextjs/app/tools/estimating-app/components/ScheduleTable.js
+++ b/frontend-nextjs/app/tools/estimating-app/components/ScheduleTable.js
@@ -1,0 +1,4 @@
+// Placeholder Schedule table component
+export default function ScheduleTable() {
+  return null;
+}

--- a/frontend-nextjs/app/tools/estimating-app/components/TakeoffInput.js
+++ b/frontend-nextjs/app/tools/estimating-app/components/TakeoffInput.js
@@ -1,0 +1,4 @@
+// Placeholder Takeoff input component
+export default function TakeoffInput() {
+  return null;
+}

--- a/frontend-nextjs/app/tools/estimating-app/data/default-rates.json
+++ b/frontend-nextjs/app/tools/estimating-app/data/default-rates.json
@@ -1,0 +1,4 @@
+{
+  "laborRate": 50,
+  "markup": 10
+}

--- a/frontend-nextjs/app/tools/estimating-app/data/sample-takeoff.json
+++ b/frontend-nextjs/app/tools/estimating-app/data/sample-takeoff.json
@@ -1,0 +1,3 @@
+[
+  { "item": "Duct", "quantity": 10, "unitCost": 20 }
+]

--- a/frontend-nextjs/app/tools/estimating-app/docs/ESTIMATOR_ONBOARDING.md
+++ b/frontend-nextjs/app/tools/estimating-app/docs/ESTIMATOR_ONBOARDING.md
@@ -1,0 +1,3 @@
+# Estimator Onboarding
+
+Placeholder onboarding steps.

--- a/frontend-nextjs/app/tools/estimating-app/docs/USER_GUIDE.md
+++ b/frontend-nextjs/app/tools/estimating-app/docs/USER_GUIDE.md
@@ -1,0 +1,3 @@
+# Estimating App User Guide
+
+Placeholder documentation.

--- a/frontend-nextjs/app/tools/estimating-app/exports/toCSV.js
+++ b/frontend-nextjs/app/tools/estimating-app/exports/toCSV.js
@@ -1,0 +1,4 @@
+export function toCSV(data) {
+  // Placeholder export logic
+  return data
+}

--- a/frontend-nextjs/app/tools/estimating-app/exports/toExcel.js
+++ b/frontend-nextjs/app/tools/estimating-app/exports/toExcel.js
@@ -1,0 +1,4 @@
+export function toExcel(data) {
+  // Placeholder export logic
+  return data
+}

--- a/frontend-nextjs/app/tools/estimating-app/exports/toPDF.js
+++ b/frontend-nextjs/app/tools/estimating-app/exports/toPDF.js
@@ -1,0 +1,4 @@
+export function toPDF(data) {
+  // Placeholder export logic
+  return data
+}

--- a/frontend-nextjs/app/tools/estimating-app/schemas/export.schema.json
+++ b/frontend-nextjs/app/tools/estimating-app/schemas/export.schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Export",
+  "type": "object",
+  "properties": {
+    "format": { "type": "string", "enum": ["csv", "pdf", "excel"] },
+    "includeBreakdown": { "type": "boolean" }
+  },
+  "required": ["format"],
+  "additionalProperties": false
+}

--- a/frontend-nextjs/app/tools/estimating-app/schemas/schedule.schema.json
+++ b/frontend-nextjs/app/tools/estimating-app/schemas/schedule.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Schedule",
+  "type": "object",
+  "properties": {
+    "activity": { "type": "string" },
+    "hours": { "type": "number", "minimum": 0 },
+    "crewSize": { "type": "number", "minimum": 1 }
+  },
+  "required": ["activity", "hours", "crewSize"],
+  "additionalProperties": false
+}

--- a/frontend-nextjs/app/tools/estimating-app/schemas/takeoff.schema.json
+++ b/frontend-nextjs/app/tools/estimating-app/schemas/takeoff.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Takeoff",
+  "type": "object",
+  "properties": {
+    "item": { "type": "string" },
+    "quantity": { "type": "number", "minimum": 0 },
+    "unitCost": { "type": "number", "minimum": 0 }
+  },
+  "required": ["item", "quantity", "unitCost"],
+  "additionalProperties": false
+}

--- a/frontend-nextjs/app/tools/estimating-app/tests/calculations.test.js
+++ b/frontend-nextjs/app/tools/estimating-app/tests/calculations.test.js
@@ -1,0 +1,5 @@
+import { calculateLabor } from '../calculations/labor'
+
+test('calculateLabor', () => {
+  expect(calculateLabor(2, 50)).toBe(100)
+})

--- a/frontend-nextjs/app/tools/estimating-app/tests/components.test.js
+++ b/frontend-nextjs/app/tools/estimating-app/tests/components.test.js
@@ -1,0 +1,7 @@
+import TakeoffInput from '../components/TakeoffInput'
+import { render } from '@testing-library/react'
+
+test('TakeoffInput renders', () => {
+  const { container } = render(<TakeoffInput />)
+  expect(container).toBeTruthy()
+})

--- a/frontend-nextjs/app/tools/estimating-app/tests/validators.test.js
+++ b/frontend-nextjs/app/tools/estimating-app/tests/validators.test.js
@@ -1,0 +1,21 @@
+import { validateSchedule } from '../validators/schedule'
+import { validateSmacna } from '../validators/smacna'
+
+const validSchedule = { activity: 'Install duct', hours: 8, crewSize: 3 }
+
+const invalidSchedule = { activity: 'Install duct', hours: -1, crewSize: 0 }
+
+test('validateSchedule passes valid data', () => {
+  const result = validateSchedule(validSchedule)
+  expect(result.valid).toBe(true)
+})
+
+test('validateSchedule fails invalid data', () => {
+  const result = validateSchedule(invalidSchedule)
+  expect(result.valid).toBe(false)
+})
+
+test('validateSmacna', () => {
+  const result = validateSmacna({ gauge: 20, jointType: 'S-slip' })
+  expect(result.valid).toBe(true)
+})

--- a/frontend-nextjs/app/tools/estimating-app/ui/layout.js
+++ b/frontend-nextjs/app/tools/estimating-app/ui/layout.js
@@ -1,0 +1,4 @@
+// Placeholder UI layout
+export default function EstimatingLayout({ children }) {
+  return children;
+}

--- a/frontend-nextjs/app/tools/estimating-app/ui/theme.json
+++ b/frontend-nextjs/app/tools/estimating-app/ui/theme.json
@@ -1,0 +1,3 @@
+{
+  "primaryColor": "#4f46e5"
+}

--- a/frontend-nextjs/app/tools/estimating-app/validators/schedule.js
+++ b/frontend-nextjs/app/tools/estimating-app/validators/schedule.js
@@ -1,0 +1,10 @@
+import Ajv from 'ajv'
+import scheduleSchema from '../schemas/schedule.schema.json' assert { type: 'json' }
+
+const ajv = new Ajv({ allErrors: true })
+const validate = ajv.compile(scheduleSchema)
+
+export function validateSchedule(data) {
+  const valid = validate(data)
+  return { valid, errors: validate.errors || [] }
+}

--- a/frontend-nextjs/app/tools/estimating-app/validators/smacna.js
+++ b/frontend-nextjs/app/tools/estimating-app/validators/smacna.js
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+
+export const smacnaSchema = z.object({
+  gauge: z.number().min(16).max(26),
+  jointType: z.string(),
+})
+
+export function validateSmacna(data) {
+  try {
+    smacnaSchema.parse(data)
+    return { valid: true, errors: [] }
+  } catch (err) {
+    return { valid: false, errors: err.errors }
+  }
+}

--- a/frontend-nextjs/app/tools/page.tsx
+++ b/frontend-nextjs/app/tools/page.tsx
@@ -48,7 +48,7 @@ export default function ToolsPage() {
       description: "Cost estimation and quantity takeoffs for HVAC projects",
       icon: <DollarSign className="w-8 h-8" />,
       status: "coming-soon",
-      href: "#",
+      href: "/tools/estimating-app",
       color: "purple",
     },
   ];


### PR DESCRIPTION
## Summary
- scaffold Estimating App with placeholder folders
- add Ajv/Zod based validators and unit tests
- update tools list to link to the new module

## Testing
- `npm install --silent` *(fails: network disabled)*
- `npm test --silent` *(not run: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68758fd0ec608321a95d617b00f92286