### PR TITLE
Update docs for estimating app

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,72 +66,38 @@ Comprehensive estimating solution addressing labor/material takeoffs and automat
 
 ```
 ├── app/
-<<<<<<< HEAD
-│   ├── demo/
-│   │   └── page.tsx         # Components demo page
-│   ├── globals.css          # Global styles with keyframes
-│   ├── layout.tsx           # Root layout
-│   └── page.tsx             # Main page with demo
-├── components/
-│   └── glassmorphism/       # Glassmorphism components
-│       ├── GlassEffect.tsx  # Base glass effect wrapper
-│       ├── GlassDock.tsx    # Icon dock component
-│       ├── GlassButton.tsx  # Glass button component
-│       ├── GlassCard.tsx    # Glass card component
-│       ├── GlassFilter.tsx  # SVG filter effects
-│       └── index.ts         # Component exports
-├── next.config.js           # Next.js configuration
-├── tailwind.config.js       # Tailwind configuration with custom animations
-└── package.json
-```
-
-## Technologies Used
-
-- **Next.js 15**: React framework with App Router
-- **React 18**: UI library
-- **TypeScript**: Type safety
-- **Tailwind CSS**: Styling
-- **tailwindcss-animate**: Additional animation utilities
-
-## License
-
-MIT License - see [LICENSE](LICENSE) file for details.
-=======
-│   └── modules/           # Individual HVAC modules
-│       ├── air-duct-sizer/
-│       ├── grease-duct-sizer/
-│       ├── engine-exhaust-sizer/
-│       ├── boiler-vent-sizer/
-│       └── estimating-app/
-├── core/                  # Shared calculation logic and validation
-│   ├── calculations/
-│   ├── validation/
-│   ├── units/
-│   └── standards/
-├── services/              # API, storage, and export services
-│   ├── api/
-│   ├── storage/
-│   └── export/
-├── frontend/              # UI components and PWA assets
-│   ├── components/
-│   ├── styles/
 │   ├── assets/
-│   └── workers/
-├── backend/               # Flask API and calculation endpoints
-│   ├── api/
-│   ├── calculations/
-│   └── exports/
-├── docs/                  # Documentation
-│   ├── user-guides/
-│   ├── api-reference/
-│   └── examples/
-└── tests/                 # Testing infrastructure
-    ├── unit/
-    ├── integration/
-    └── e2e/
+│   ├── config/
+│   │   └── environment/
+│   ├── core/
+│   ├── data/
+│   ├── docs/
+│   ├── hooks/
+│   ├── i18n/
+│   ├── plugins/
+│   ├── services/
+│   ├── simulations/
+│   ├── static/
+│   ├── templates/
+│   ├── tests/
+│   └── tools/
+│       ├── duct-sizer/
+│       ├── grease-sizer/
+│       ├── boiler-sizer/
+│       ├── engine-exhaust/
+│       └── estimating-app/
+├── backend/
+├── frontend/
+├── frontend-nextjs/
+├── docs/
+└── tests/
 ```
+
+All HVAC tools live inside `/app/tools/`. The Estimating App resides in `/app/tools/estimating-app/`.
 
 ## Getting Started
+
+The repository is organized around the `/app` directory. Each HVAC tool, including the new Estimating App, resides under `/app/tools/`.
 
 ### Prerequisites
 
@@ -296,4 +262,3 @@ make html
 ## Support
 
 For questions and support, please refer to the documentation or create an issue in the repository.
->>>>>>> main

--- a/docs/estimating-app.md
+++ b/docs/estimating-app.md
@@ -1,0 +1,31 @@
+# Estimating App – Folder Rationale and Usage
+**For the SizeWise Suite Platform**
+_Last updated: 2025-07-13_
+
+---
+
+The `app/tools/estimating-app` directory centralizes all estimation logic for SizeWise Suite. Each subfolder fulfills a specific role and mirrors the overall standards-driven philosophy of the platform.
+
+## Folder Overview
+
+| Folder | Purpose |
+| ------ | ------- |
+| **components/** | Reusable UI widgets such as takeoff tables and bid summaries. |
+| **calculations/** | Core math for labor, material, and markup computations. |
+| **validators/** | Validates schedules and takeoffs against SMACNA and project rules. |
+| **schemas/** | AJV/Zod schemas defining all data models (takeoff, schedule, export). |
+| **ui/** | Theme files and layouts supporting metric/imperial workflows. |
+| **data/** | Example bids, default rate tables, and sample takeoffs. |
+| **docs/** | Developer and estimator guides for onboarding. |
+| **tests/** | Unit and integration tests (≥85% coverage target). |
+| **exports/** | Scripts for generating Excel, PDF, and CSV bids. |
+
+## Usage
+
+1. **Open the Estimating App** from the SizeWise Suite interface.
+2. **Create or import a takeoff** using forms in `components/`.
+3. **Adjust labor and material rates** stored in `data/` or pull defaults from `/core/` services.
+4. **Run validation** to ensure compliance with project standards via the modules in `validators/`.
+5. **Export bids** using the scripts found in `exports/` for Excel, PDF, or CSV output.
+
+All modules are testable in isolation, and every `.json` file under `schemas/` or `data/` requires schema validation. This structure ensures easy maintenance and auditability while supporting future estimating verticals.

--- a/docs/user-guide/estimating-app.md
+++ b/docs/user-guide/estimating-app.md
@@ -1,0 +1,24 @@
+# Estimating App – User Guide
+**For the SizeWise Suite Platform**
+_Last updated: 2025-07-13_
+
+---
+
+The Estimating App provides fast, standards‑compliant bidding for HVAC projects. It lives in `app/tools/estimating-app/` and integrates with the shared calculations and validators in `/app/core/`.
+
+## 1. Key Features
+
+- Quantity takeoff with scheduling and alternates
+- Labor and material costing with markup controls
+- Metric and Imperial workflows with standards overrides
+- Batch exports to Excel, PDF, and CSV formats
+
+## 2. Basic Workflow
+
+1. **Launch** the Estimating App from the main SizeWise interface.
+2. **Create a new estimate** or import takeoff data from a spreadsheet.
+3. **Edit rates and exclusions** as needed.
+4. **Validate** the schedule against built‑in SMACNA rules.
+5. **Export** a formatted bid sheet for client or internal review.
+
+For detailed folder rationale and developer information, see [Estimating App – Folder Rationale and Usage](../estimating-app.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
   - User Guide:
     - Overview: user-guide/overview.md
     - Air Duct Sizer: user-guide/air-duct-sizer.md
+    - Estimating App: user-guide/estimating-app.md
     - Project Management: user-guide/project-management.md
     - Units and Standards: user-guide/units-standards.md
     - Offline Usage: user-guide/offline-usage.md


### PR DESCRIPTION
## Summary
- document Estimating App folder structure and usage
- add user guide section for the Estimating App
- include Estimating App in MkDocs navigation
- clean up README and reference new `/app` layout

## Testing
- `npm test` *(fails: jest not found)*
- `python -m pytest tests` *(fails: ModuleNotFoundError: structlog)*

------
https://chatgpt.com/codex/tasks/task_e_68758fd632308321bdefdb95ce541983