### PR TITLE
Add offline storage

### DIFF
--- a/app/core/storage/db.ts
+++ b/app/core/storage/db.ts
@@ -1,0 +1,41 @@
+import Dexie, { Table } from 'dexie'
+
+export interface Project {
+  id?: number
+  name: string
+  created: string
+  modified: string
+}
+
+export interface Takeoff {
+  id?: number
+  projectId: number
+  name: string
+  created: string
+  modified: string
+}
+
+export interface ExportRecord {
+  id?: number
+  projectId: number
+  type: string
+  created: string
+}
+
+class SizeWiseDB extends Dexie {
+  projects!: Table<Project, number>
+  takeoffs!: Table<Takeoff, number>
+  exports!: Table<ExportRecord, number>
+
+  constructor() {
+    super('SizeWiseDB')
+    this.version(1).stores({
+      projects: '++id,name,created,modified',
+      takeoffs: '++id,projectId,name,created,modified',
+      exports: '++id,projectId,type,created'
+    })
+  }
+}
+
+const db = new SizeWiseDB()
+export default db

--- a/app/tools/estimating-app/components/ProjectList.js
+++ b/app/tools/estimating-app/components/ProjectList.js
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react'
+import db from '../../../core/storage/db'
+
+export default function ProjectList({ onSelect }) {
+  const [projects, setProjects] = useState([])
+
+  useEffect(() => {
+    const load = async () => {
+      const all = await db.projects.toArray()
+      setProjects(all)
+    }
+    load()
+  }, [])
+
+  const addProject = async () => {
+    const now = new Date().toISOString()
+    const id = await db.projects.add({
+      name: `Project ${projects.length + 1}`,
+      created: now,
+      modified: now
+    })
+    const updated = await db.projects.toArray()
+    setProjects(updated)
+    onSelect && onSelect(id)
+  }
+
+  return (
+    <div>
+      <button onClick={addProject}>Add Project</button>
+      <ul>
+        {projects.map(p => (
+          <li key={p.id}>
+            <button onClick={() => onSelect && onSelect(p.id)}>{p.name}</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/app/tools/estimating-app/components/TakeoffInput.js
+++ b/app/tools/estimating-app/components/TakeoffInput.js
@@ -1,0 +1,29 @@
+import React, { useState } from 'react'
+import db from '../../../core/storage/db'
+
+export default function TakeoffInput({ projectId, onSaved }) {
+  const [name, setName] = useState('')
+
+  const saveTakeoff = async () => {
+    const now = new Date().toISOString()
+    const id = await db.takeoffs.add({
+      projectId,
+      name,
+      created: now,
+      modified: now
+    })
+    onSaved && onSaved(id)
+    setName('')
+  }
+
+  return (
+    <div>
+      <input
+        value={name}
+        onChange={e => setName(e.target.value)}
+        placeholder="Takeoff Name"
+      />
+      <button onClick={saveTakeoff}>Save Takeoff</button>
+    </div>
+  )
+}

--- a/app/tools/estimating-app/tests/db.test.js
+++ b/app/tools/estimating-app/tests/db.test.js
@@ -1,0 +1,32 @@
+import db from '../../core/storage/db'
+
+describe('Dexie offline storage', () => {
+  beforeEach(async () => {
+    await db.delete()
+    await db.open()
+  })
+
+  test('saves and retrieves project', async () => {
+    const id = await db.projects.add({
+      name: 'Test',
+      created: 'now',
+      modified: 'now'
+    })
+    const project = await db.projects.get(id)
+    expect(project?.name).toBe('Test')
+  })
+
+  test('stores takeoff linked to project', async () => {
+    const projectId = await db.projects.add({ name: 'P', created: 'c', modified: 'm' })
+    const takeoffId = await db.takeoffs.add({ projectId, name: 'T', created: 'c', modified: 'm' })
+    const takeoff = await db.takeoffs.get(takeoffId)
+    expect(takeoff?.projectId).toBe(projectId)
+  })
+
+  test('records exports', async () => {
+    const projectId = await db.projects.add({ name: 'P', created: 'c', modified: 'm' })
+    const exportId = await db.exports.add({ projectId, type: 'pdf', created: 'c' })
+    const record = await db.exports.get(exportId)
+    expect(record?.type).toBe('pdf')
+  })
+})

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,7 @@ module.exports = {
       targets: {
         node: 'current'
       }
-    }]
+    }],
+    '@babel/preset-typescript'
   ]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,9 +3,11 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/tests/setup.js'],
   testMatch: [
     '<rootDir>/tests/**/*.test.js',
-    '<rootDir>/tests/**/*.spec.js'
+    '<rootDir>/tests/**/*.spec.js',
+    '<rootDir>/app/tools/estimating-app/tests/**/*.test.js'
   ],
   collectCoverageFrom: [
+    'app/tools/estimating-app/**/*.js',
     'frontend/js/**/*.js',
     'core/**/*.py',
     '!frontend/js/main.js',

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@babel/core": "^7.23.0",
     "@babel/preset-env": "^7.23.0",
+    "@babel/preset-typescript": "^7.23.0",
     "@types/jest": "^29.5.5",
     "@typescript-eslint/eslint-plugin": "^6.7.4",
     "@typescript-eslint/parser": "^6.7.4",


### PR DESCRIPTION
## Summary
- configure Dexie database for offline data
- integrate storage helpers with estimating components
- cover Dexie helpers with fake-indexeddb tests
- extend Jest config and Babel typescript preset

## Testing
- `npm test` *(fails: jest not found)*
- `python -m pytest -q tests/unit/backend/test_air_duct_calculator.py` *(fails: ModuleNotFoundError: structlog)*

------
https://chatgpt.com/codex/tasks/task_e_68758fd4e348832189002968bc18eb77