### PR TITLE
style: unify design tokens

### DIFF
--- a/app/config/design-tokens.json
+++ b/app/config/design-tokens.json
@@ -1,0 +1,39 @@
+{
+  "color": {
+    "primary": "#1976d2",
+    "primary-dark": "#1565c0",
+    "primary-light": "#42a5f5",
+    "secondary": "#424242",
+    "accent": "#ff9800",
+    "highlight": "#3b82f6",
+    "success": "#4caf50",
+    "warning": "#ff9800",
+    "error": "#f44336",
+    "info": "#2196f3",
+    "background": "#f5f5f5",
+    "surface": "#ffffff",
+    "text-primary": "#212121",
+    "text-secondary": "#757575",
+    "text-disabled": "#bdbdbd",
+    "border": "#e0e0e0",
+    "grid-light": "#e5e7eb",
+    "grid-dark": "#d1d5db",
+    "label": "#374151",
+    "label-secondary": "#6366f1",
+    "positive": "#059669"
+  },
+  "spacing": {
+    "xs": "4px",
+    "sm": "8px",
+    "md": "16px",
+    "lg": "24px",
+    "xl": "32px"
+  },
+  "typography": {
+    "font-family": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif",
+    "font-size-base": "14px",
+    "font-size-small": "12px",
+    "font-size-large": "16px",
+    "font-size-xl": "20px"
+  }
+}

--- a/docs/developer-guide/design-tokens.md
+++ b/docs/developer-guide/design-tokens.md
@@ -1,0 +1,31 @@
+# Design Tokens
+
+The global design tokens are defined in `app/config/design-tokens.json`. These tokens centralize colors, spacing, and typography for both the legacy frontend and the Next.js application.
+
+## Usage
+
+### CSS
+
+Both `frontend/styles/main.css` and `frontend-nextjs/app/globals.css` expose the tokens as CSS variables under the `:root` selector. Reference them with `var(--color-primary)`, `var(--spacing-md)`, etc.
+
+### Components
+
+When canvas components require colors, tokens are imported directly:
+
+```ts
+import tokens from '@/shared/designTokens'
+```
+
+This ensures rendering is consistent across modules and avoids hard-coded values.
+
+## Token Structure
+
+```json
+{
+  "color": { "primary": "#1976d2", "secondary": "#424242", ... },
+  "spacing": { "md": "16px", ... },
+  "typography": { "font-size-base": "14px", ... }
+}
+```
+
+Update the JSON file to change the theme globally.

--- a/frontend-nextjs/app/globals.css
+++ b/frontend-nextjs/app/globals.css
@@ -2,6 +2,30 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --color-primary: #1976d2;
+  --color-primary-dark: #1565c0;
+  --color-primary-light: #42a5f5;
+  --color-secondary: #424242;
+  --color-accent: #ff9800;
+  --color-success: #4caf50;
+  --color-warning: #ff9800;
+  --color-error: #f44336;
+  --color-info: #2196f3;
+  --color-highlight: #3b82f6;
+  --color-background: #f5f5f5;
+  --color-surface: #ffffff;
+  --color-text-primary: #212121;
+  --color-text-secondary: #757575;
+  --color-text-disabled: #bdbdbd;
+  --color-border: #e0e0e0;
+  --color-grid-light: #e5e7eb;
+  --color-grid-dark: #d1d5db;
+  --color-label: #374151;
+  --color-label-secondary: #6366f1;
+  --color-positive: #059669;
+}
+
 /* Custom keyframes - moveBackground removed as no longer needed */
 
 /* Ensure backdrop-filter works properly */
@@ -57,11 +81,11 @@
 /* High contrast mode support */
 @media (prefers-contrast: high) {
   .border-neutral-200 {
-    border-color: #000;
+    border-color: var(--color-text-primary);
   }
 
   .dark .border-neutral-700 {
-    border-color: #fff;
+    border-color: var(--color-surface);
   }
 }
 
@@ -84,7 +108,7 @@
 .focus\:ring-2:focus-visible {
   outline: 2px solid transparent;
   outline-offset: 2px;
-  box-shadow: 0 0 0 2px var(--ring-color, #3b82f6);
+  box-shadow: 0 0 0 2px var(--ring-color, var(--color-highlight));
 }
 
 /* Smooth scrolling for better UX */

--- a/frontend-nextjs/components/canvas/DrawingPreview.tsx
+++ b/frontend-nextjs/components/canvas/DrawingPreview.tsx
@@ -3,6 +3,15 @@
 import React from 'react'
 import { Group, Rect, Line } from 'react-konva'
 import { useUIStore } from '@/stores/ui-store'
+import tokens from '@/shared/designTokens'
+
+const hexToRgb = (hex: string) => {
+  const h = hex.replace('#', '')
+  const r = parseInt(h.substring(0, 2), 16)
+  const g = parseInt(h.substring(2, 4), 16)
+  const b = parseInt(h.substring(4, 6), 16)
+  return `${r}, ${g}, ${b}`
+}
 
 export const DrawingPreview: React.FC = () => {
   const { drawingState } = useUIStore()
@@ -36,8 +45,8 @@ export const DrawingPreview: React.FC = () => {
         y={y}
         width={width}
         height={height}
-        fill="rgba(59, 130, 246, 0.2)"
-        stroke="#3b82f6"
+        fill={`rgba(${hexToRgb(tokens.color.highlight)}, 0.2)`}
+        stroke={tokens.color.highlight}
         strokeWidth={2}
         dash={[5, 5]}
         listening={false}
@@ -49,7 +58,7 @@ export const DrawingPreview: React.FC = () => {
     return (
       <Line
         points={[startPoint.x, startPoint.y, endPoint.x, endPoint.y]}
-        stroke="#3b82f6"
+        stroke={tokens.color.highlight}
         strokeWidth={3}
         lineCap="round"
         dash={[5, 5]}

--- a/frontend-nextjs/components/canvas/DuctSegment.tsx
+++ b/frontend-nextjs/components/canvas/DuctSegment.tsx
@@ -6,6 +6,7 @@ import Konva from 'konva'
 import { Segment } from '@/types/air-duct-sizer'
 import { useProjectStore } from '@/stores/project-store'
 import { useUIStore } from '@/stores/ui-store'
+import tokens from '@/shared/designTokens'
 
 interface DuctSegmentProps {
   segment: Segment
@@ -60,25 +61,25 @@ export const DuctSegment: React.FC<DuctSegmentProps> = ({ segment, isSelected, o
   
   // Get segment color based on warnings and selection
   const getSegmentColor = () => {
-    if (isSelected) return '#3b82f6' // Blue when selected
+    if (isSelected) return tokens.color.highlight // Blue when selected
     
     // Check for warnings
     if (segment.warnings && segment.warnings.length > 0) {
       const hasError = segment.warnings.some(w => w.severity === 'critical')
       const hasWarning = segment.warnings.some(w => w.severity === 'warning')
       
-      if (hasError) return '#ef4444' // Red for errors
-      if (hasWarning) return '#f59e0b' // Orange for warnings
+      if (hasError) return tokens.color.error // Red for errors
+      if (hasWarning) return tokens.color.warning // Orange for warnings
     }
     
     // Color based on velocity (if calculated)
     if (segment.velocity) {
-      if (segment.velocity > 2000) return '#ef4444' // Red for high velocity
-      if (segment.velocity > 1500) return '#f59e0b' // Orange for medium-high velocity
-      if (segment.velocity < 600) return '#6b7280' // Gray for low velocity
+      if (segment.velocity > 2000) return tokens.color.error // Red for high velocity
+      if (segment.velocity > 1500) return tokens.color.warning // Orange for medium-high velocity
+      if (segment.velocity < 600) return tokens.color.label // Gray for low velocity
     }
     
-    return '#374151' // Default dark gray
+    return tokens.color.label // Default dark gray
   }
   
   // Get stroke width based on duct size
@@ -108,8 +109,8 @@ export const DuctSegment: React.FC<DuctSegmentProps> = ({ segment, isSelected, o
           x={x1}
           y={y1}
           radius={6}
-          fill="#ffffff"
-          stroke="#3b82f6"
+          fill={tokens.color.surface}
+          stroke={tokens.color.highlight}
           strokeWidth={2}
           draggable={true}
           onDragMove={(e) => handlePointDrag(0, e)}
@@ -120,8 +121,8 @@ export const DuctSegment: React.FC<DuctSegmentProps> = ({ segment, isSelected, o
           x={x2}
           y={y2}
           radius={6}
-          fill="#ffffff"
-          stroke="#3b82f6"
+          fill={tokens.color.surface}
+          stroke={tokens.color.highlight}
           strokeWidth={2}
           draggable={true}
           onDragMove={(e) => handlePointDrag(1, e)}
@@ -149,7 +150,7 @@ export const DuctSegment: React.FC<DuctSegmentProps> = ({ segment, isSelected, o
           text={getSegmentSizeText()}
           fontSize={fontSize}
           fontFamily="Arial"
-          fill="#374151"
+          fill={tokens.color.label}
           align="center"
           offsetX={getSegmentSizeText().length * 3} // Approximate centering
           listening={false}
@@ -163,7 +164,7 @@ export const DuctSegment: React.FC<DuctSegmentProps> = ({ segment, isSelected, o
             text={`${Math.round(segment.velocity)} FPM`}
             fontSize={fontSize * 0.8}
             fontFamily="Arial"
-            fill="#059669"
+            fill={tokens.color.positive}
             align="center"
             offsetX={`${Math.round(segment.velocity)} FPM`.length * 2.5}
             listening={false}
@@ -178,7 +179,7 @@ export const DuctSegment: React.FC<DuctSegmentProps> = ({ segment, isSelected, o
             text={`${Math.round(segment.airflow)} CFM`}
             fontSize={fontSize * 0.8}
             fontFamily="Arial"
-            fill="#6366f1"
+            fill={tokens.color['label-secondary']}
             align="center"
             offsetX={`${Math.round(segment.airflow)} CFM`.length * 2.5}
             listening={false}
@@ -212,8 +213,8 @@ export const DuctSegment: React.FC<DuctSegmentProps> = ({ segment, isSelected, o
         x={midX + 15}
         y={midY - 15}
         radius={8}
-        fill={hasError ? '#ef4444' : '#f59e0b'}
-        stroke="#ffffff"
+        fill={hasError ? tokens.color.error : tokens.color.warning}
+        stroke={tokens.color.surface}
         strokeWidth={2}
         listening={false}
       />
@@ -237,7 +238,7 @@ export const DuctSegment: React.FC<DuctSegmentProps> = ({ segment, isSelected, o
       {isSelected && (
         <Line
           points={points}
-          stroke="#3b82f6"
+          stroke={tokens.color.highlight}
           strokeWidth={getStrokeWidth() + 2}
           lineCap="round"
           lineJoin="round"

--- a/frontend-nextjs/components/canvas/Grid.tsx
+++ b/frontend-nextjs/components/canvas/Grid.tsx
@@ -3,6 +3,7 @@
 import React from 'react'
 import { Group, Line } from 'react-konva'
 import { useUIStore } from '@/stores/ui-store'
+import tokens from '@/shared/designTokens'
 
 interface GridProps {
   size: number
@@ -28,7 +29,7 @@ export const Grid: React.FC<GridProps> = ({ size }) => {
       <Line
         key={`v-${x}`}
         points={[x, startY, x, endY]}
-        stroke="#e5e7eb"
+        stroke={tokens.color['grid-light']}
         strokeWidth={0.5}
         listening={false}
       />
@@ -42,7 +43,7 @@ export const Grid: React.FC<GridProps> = ({ size }) => {
       <Line
         key={`h-${y}`}
         points={[startX, y, endX, y]}
-        stroke="#e5e7eb"
+        stroke={tokens.color['grid-light']}
         strokeWidth={0.5}
         listening={false}
       />
@@ -56,7 +57,7 @@ export const Grid: React.FC<GridProps> = ({ size }) => {
       <Line
         key={`mv-${x}`}
         points={[x, startY, x, endY]}
-        stroke="#d1d5db"
+        stroke={tokens.color['grid-dark']}
         strokeWidth={1}
         listening={false}
       />
@@ -69,7 +70,7 @@ export const Grid: React.FC<GridProps> = ({ size }) => {
       <Line
         key={`mh-${y}`}
         points={[startX, y, endX, y]}
-        stroke="#d1d5db"
+        stroke={tokens.color['grid-dark']}
         strokeWidth={1}
         listening={false}
       />

--- a/frontend-nextjs/components/canvas/Room.tsx
+++ b/frontend-nextjs/components/canvas/Room.tsx
@@ -6,6 +6,7 @@ import Konva from 'konva'
 import { Room as RoomType } from '@/types/air-duct-sizer'
 import { useProjectStore } from '@/stores/project-store'
 import { useUIStore } from '@/stores/ui-store'
+import tokens from '@/shared/designTokens'
 
 interface RoomProps {
   room: RoomType
@@ -69,14 +70,14 @@ export const Room: React.FC<RoomProps> = ({ room, isSelected, onSelect }) => {
   
   // Room color based on selection and warnings
   const getRoomColor = () => {
-    if (isSelected) return '#3b82f6' // Blue when selected
+    if (isSelected) return tokens.color.highlight // Blue when selected
     // TODO: Add warning colors based on room.warnings
-    return '#f3f4f6' // Default gray
+    return tokens.color['grid-light'] // Default gray
   }
   
   const getStrokeColor = () => {
-    if (isSelected) return '#1d4ed8' // Darker blue when selected
-    return '#6b7280' // Default gray
+    if (isSelected) return tokens.color['primary-dark'] // Darker blue when selected
+    return tokens.color.label // Default gray
   }
   
   // Resize handles (only show when selected)
@@ -98,8 +99,8 @@ export const Room: React.FC<RoomProps> = ({ room, isSelected, onSelect }) => {
         x={handle.x}
         y={handle.y}
         radius={handleSize / 2}
-        fill="#ffffff"
-        stroke="#3b82f6"
+        fill={tokens.color.surface}
+        stroke={tokens.color.highlight}
         strokeWidth={2}
         draggable={false}
         listening={false}
@@ -135,7 +136,7 @@ export const Room: React.FC<RoomProps> = ({ room, isSelected, onSelect }) => {
         text={room.name}
         fontSize={fontSize}
         fontFamily="Arial"
-        fill="#374151"
+        fill={tokens.color.label}
         align="center"
         verticalAlign="middle"
         offsetX={textX}
@@ -149,7 +150,7 @@ export const Room: React.FC<RoomProps> = ({ room, isSelected, onSelect }) => {
         text={`${room.dimensions.length.toFixed(1)}' × ${room.dimensions.width.toFixed(1)}'`}
         fontSize={fontSize * 0.7}
         fontFamily="Arial"
-        fill="#6b7280"
+        fill={tokens.color['text-secondary']}
         align="center"
         verticalAlign="middle"
         offsetX={textX}
@@ -164,7 +165,7 @@ export const Room: React.FC<RoomProps> = ({ room, isSelected, onSelect }) => {
           text={`${room.airflow} CFM`}
           fontSize={fontSize * 0.6}
           fontFamily="Arial"
-          fill="#059669"
+          fill={tokens.color.positive}
           align="center"
           verticalAlign="middle"
           offsetX={textX}

--- a/frontend-nextjs/components/canvas/SelectionBox.tsx
+++ b/frontend-nextjs/components/canvas/SelectionBox.tsx
@@ -3,6 +3,15 @@
 import React from 'react'
 import { Rect } from 'react-konva'
 import { useUIStore } from '@/stores/ui-store'
+import tokens from '@/shared/designTokens'
+
+const hexToRgb = (hex: string) => {
+  const h = hex.replace('#', '')
+  const r = parseInt(h.substring(0, 2), 16)
+  const g = parseInt(h.substring(2, 4), 16)
+  const b = parseInt(h.substring(4, 6), 16)
+  return `${r}, ${g}, ${b}`
+}
 
 export const SelectionBox: React.FC = () => {
   const { selectionBox } = useUIStore()
@@ -15,8 +24,8 @@ export const SelectionBox: React.FC = () => {
       y={selectionBox.y}
       width={selectionBox.width}
       height={selectionBox.height}
-      fill="rgba(59, 130, 246, 0.1)"
-      stroke="#3b82f6"
+      fill={`rgba(${hexToRgb(tokens.color.highlight)}, 0.1)`}
+      stroke={tokens.color.highlight}
       strokeWidth={1}
       dash={[5, 5]}
       listening={false}

--- a/frontend-nextjs/shared/designTokens.ts
+++ b/frontend-nextjs/shared/designTokens.ts
@@ -1,0 +1,3 @@
+import tokens from '../../app/config/design-tokens.json'
+
+export default tokens

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,8 +34,8 @@
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
             line-height: 1.6;
-            color: #333;
-            background-color: #f5f5f5;
+            color: var(--color-text-primary);
+            background-color: var(--color-background);
         }
         
         .loading {
@@ -44,7 +44,7 @@
             align-items: center;
             height: 100vh;
             font-size: 1.2rem;
-            color: #666;
+            color: var(--color-text-secondary);
         }
         
         .loading::after {
@@ -52,8 +52,8 @@
             width: 20px;
             height: 20px;
             margin-left: 10px;
-            border: 2px solid #ddd;
-            border-top: 2px solid #1976d2;
+            border: 2px solid var(--color-grid-light);
+            border-top: 2px solid var(--color-primary);
             border-radius: 50%;
             animation: spin 1s linear infinite;
         }

--- a/frontend/styles/main.css
+++ b/frontend/styles/main.css
@@ -2,23 +2,30 @@
 
 /* CSS Variables for theming */
 :root {
-  --primary-color: #1976d2;
-  --primary-dark: #1565c0;
-  --primary-light: #42a5f5;
-  --secondary-color: #424242;
-  --accent-color: #ff9800;
-  --success-color: #4caf50;
-  --warning-color: #ff9800;
-  --error-color: #f44336;
-  --info-color: #2196f3;
+  --color-primary: #1976d2;
+  --color-primary-dark: #1565c0;
+  --color-primary-light: #42a5f5;
+  --color-secondary: #424242;
+  --color-accent: #ff9800;
+  --color-success: #4caf50;
+  --color-warning: #ff9800;
+  --color-error: #f44336;
+  --color-info: #2196f3;
+  --color-highlight: #3b82f6;
+
+  --color-background: #f5f5f5;
+  --color-surface: #ffffff;
+  --color-text-primary: #212121;
+  --color-text-secondary: #757575;
+  --color-text-disabled: #bdbdbd;
+  --color-border: #e0e0e0;
+  --color-grid-light: #e5e7eb;
+  --color-grid-dark: #d1d5db;
+  --color-label: #374151;
+  --color-label-secondary: #6366f1;
+  --color-positive: #059669;
   
-  --background-color: #f5f5f5;
-  --surface-color: #ffffff;
-  --text-primary: #212121;
-  --text-secondary: #757575;
-  --text-disabled: #bdbdbd;
-  
-  --border-color: #e0e0e0;
+  --color-border: #e0e0e0;
   --border-radius: 4px;
   --box-shadow: 0 2px 4px rgba(0,0,0,0.1);
   --box-shadow-elevated: 0 4px 8px rgba(0,0,0,0.15);
@@ -54,8 +61,8 @@ html {
 
 body {
   font-family: var(--font-family);
-  color: var(--text-primary);
-  background-color: var(--background-color);
+  color: var(--color-text-primary);
+  background-color: var(--color-background);
   overflow-x: hidden;
 }
 
@@ -74,7 +81,7 @@ body {
 /* Header */
 #app-header {
   grid-area: header;
-  background-color: var(--primary-color);
+  background-color: var(--color-primary);
   color: white;
   box-shadow: var(--box-shadow);
   z-index: 1000;
@@ -125,8 +132,8 @@ body {
 /* Sidebar */
 #sidebar {
   grid-area: sidebar;
-  background-color: var(--surface-color);
-  border-right: 1px solid var(--border-color);
+  background-color: var(--color-surface);
+  border-right: 1px solid var(--color-border);
   overflow-y: auto;
   transition: transform 0.3s ease;
 }
@@ -146,7 +153,7 @@ body {
 .nav-section-title {
   font-size: var(--font-size-small);
   font-weight: 600;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   margin-bottom: var(--spacing-xs);
@@ -161,19 +168,19 @@ body {
 .nav-link {
   display: block;
   padding: var(--spacing-sm) var(--spacing-md);
-  color: var(--text-primary);
+  color: var(--color-text-primary);
   text-decoration: none;
   border-radius: var(--border-radius);
   transition: all 0.2s ease;
 }
 
 .nav-link:hover {
-  background-color: var(--primary-light);
+  background-color: var(--color-primary-light);
   color: white;
 }
 
 .nav-link.active {
-  background-color: var(--primary-color);
+  background-color: var(--color-primary);
   color: white;
 }
 
@@ -181,7 +188,7 @@ body {
 #main-content {
   grid-area: main;
   overflow-y: auto;
-  background-color: var(--background-color);
+  background-color: var(--color-background);
 }
 
 .content-area {
@@ -191,7 +198,7 @@ body {
 }
 
 .module-content {
-  background-color: var(--surface-color);
+  background-color: var(--color-surface);
   border-radius: var(--border-radius);
   box-shadow: var(--box-shadow);
   padding: var(--spacing-lg);
@@ -200,7 +207,7 @@ body {
 
 .module-content h2 {
   margin-bottom: var(--spacing-md);
-  color: var(--primary-color);
+  color: var(--color-primary);
 }
 
 /* Dashboard */
@@ -212,8 +219,8 @@ body {
 }
 
 .action-card {
-  background-color: var(--surface-color);
-  border: 1px solid var(--border-color);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: var(--border-radius);
   padding: var(--spacing-lg);
   text-align: center;
@@ -226,12 +233,12 @@ body {
 }
 
 .action-card h3 {
-  color: var(--primary-color);
+  color: var(--color-primary);
   margin-bottom: var(--spacing-sm);
 }
 
 .action-card p {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   margin-bottom: var(--spacing-md);
 }
 
@@ -248,14 +255,14 @@ body {
   display: block;
   margin-bottom: var(--spacing-xs);
   font-weight: 500;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
 }
 
 .form-group input,
 .form-group select {
   width: 100%;
   padding: var(--spacing-sm) var(--spacing-md);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--color-border);
   border-radius: var(--border-radius);
   font-size: var(--font-size-base);
   transition: border-color 0.2s ease;
@@ -264,7 +271,7 @@ body {
 .form-group input:focus,
 .form-group select:focus {
   outline: none;
-  border-color: var(--primary-color);
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 2px rgba(25, 118, 210, 0.2);
 }
 
@@ -296,16 +303,16 @@ body {
 }
 
 .btn-primary {
-  background-color: var(--primary-color);
+  background-color: var(--color-primary);
   color: white;
 }
 
 .btn-primary:hover:not(:disabled) {
-  background-color: var(--primary-dark);
+  background-color: var(--color-primary-dark);
 }
 
 .btn-secondary {
-  background-color: var(--secondary-color);
+  background-color: var(--color-secondary);
   color: white;
 }
 
@@ -325,7 +332,7 @@ body {
   padding: var(--spacing-lg);
   background-color: #f8f9fa;
   border-radius: var(--border-radius);
-  border-left: 4px solid var(--primary-color);
+  border-left: 4px solid var(--color-primary);
 }
 
 .results-grid {
@@ -342,17 +349,17 @@ body {
   padding: var(--spacing-sm);
   background-color: white;
   border-radius: var(--border-radius);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--color-border);
 }
 
 .result-item label {
   font-weight: 500;
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .result-item span {
   font-weight: 600;
-  color: var(--text-primary);
+  color: var(--color-text-primary);
 }
 
 .compliance-section {
@@ -370,17 +377,17 @@ body {
 
 .compliance-status.compliant {
   background-color: #e8f5e8;
-  color: var(--success-color);
+  color: var(--color-success);
 }
 
 .compliance-status.non-compliant {
   background-color: #ffebee;
-  color: var(--error-color);
+  color: var(--color-error);
 }
 
 .compliance-note {
   font-size: var(--font-size-small);
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   margin-bottom: var(--spacing-xs);
 }
 
@@ -389,7 +396,7 @@ body {
   align-items: center;
   gap: var(--spacing-sm);
   padding: var(--spacing-xs) 0;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .check-parameter {
@@ -403,16 +410,16 @@ body {
 }
 
 .check-status.passed {
-  color: var(--success-color);
+  color: var(--color-success);
 }
 
 .check-status.failed {
-  color: var(--error-color);
+  color: var(--color-error);
 }
 
 .check-message {
   font-size: var(--font-size-small);
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   flex: 1;
 }
 
@@ -425,7 +432,7 @@ body {
 }
 
 .warnings-section h4 {
-  color: var(--warning-color);
+  color: var(--color-warning);
   margin-bottom: var(--spacing-sm);
 }
 
@@ -441,8 +448,8 @@ body {
 /* Status bar */
 #status-bar {
   grid-area: status;
-  background-color: var(--surface-color);
-  border-top: 1px solid var(--border-color);
+  background-color: var(--color-surface);
+  border-top: 1px solid var(--color-border);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -471,15 +478,15 @@ body {
 }
 
 .status-indicator.online::before {
-  background-color: var(--success-color);
+  background-color: var(--color-success);
 }
 
 .status-indicator.offline::before {
-  background-color: var(--error-color);
+  background-color: var(--color-error);
 }
 
 .status-text {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 /* Utility classes */
@@ -492,7 +499,7 @@ body {
 }
 
 .text-muted {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .mb-0 { margin-bottom: 0; }
@@ -508,7 +515,7 @@ body {
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: var(--background-color);
+  background-color: var(--color-background);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -518,19 +525,19 @@ body {
 .error-content {
   text-align: center;
   padding: var(--spacing-xl);
-  background-color: var(--surface-color);
+  background-color: var(--color-surface);
   border-radius: var(--border-radius);
   box-shadow: var(--box-shadow-elevated);
   max-width: 400px;
 }
 
 .error-content h2 {
-  color: var(--error-color);
+  color: var(--color-error);
   margin-bottom: var(--spacing-md);
 }
 
 .error-content p {
-  color: var(--text-secondary);
+  color: var(--color-text-secondary);
   margin-bottom: var(--spacing-lg);
 }
 
@@ -631,13 +638,13 @@ body {
 }
 
 .notification.success {
-  background-color: var(--success-color);
+  background-color: var(--color-success);
 }
 
 .notification.warning {
-  background-color: var(--warning-color);
+  background-color: var(--color-warning);
 }
 
 .notification.error {
-  background-color: var(--error-color);
+  background-color: var(--color-error);
 }


### PR DESCRIPTION
## Summary
- add shared design tokens in `app/config/design-tokens.json`
- expose tokens via CSS variables in both apps
- refactor canvas components to import tokens
- document how to use tokens

## Testing
- `npm test` *(fails: jest not found)*
- `python -m pytest tests/` *(fails: structlog missing)*

------
https://chatgpt.com/codex/tasks/task_e_68758fd2f6c48321a5ae789c9d8e48d9