### PR TITLE
docs: sanitize Sentry credentials

### DIFF
--- a/SENTRY_CI_SETUP.md
+++ b/SENTRY_CI_SETUP.md
@@ -16,8 +16,8 @@ This document outlines the completed Sentry authentication token setup for your 
 - Cleaned up conflicting root-level files
 
 ✅ **Configuration Verified**:
-- Auth token confirmed: `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`
-- DSN standardized: `https://7c66eaefa7b2dde6957e18ffb03bf28f@o4509734387056640.ingest.us.sentry.io/4509734389481472`
+- Auth token confirmed: `<YOUR_SENTRY_AUTH_TOKEN>`
+- DSN standardized: `<YOUR_SENTRY_DSN>`
 - Organization: `sizewise`
 - Project: `javascript-nextjs`
 
@@ -31,7 +31,7 @@ You still need to add the Sentry auth token as a GitHub repository secret:
 3. Click **New repository secret**
 4. Set the following:
    - **Name**: `SENTRY_AUTH_TOKEN`
-   - **Secret**: `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`
+   - **Secret**: `<YOUR_SENTRY_AUTH_TOKEN>`
 5. Click **Add secret**
 
 ### Expected Results

--- a/SENTRY_FLASK_SETUP_COMPLETE.md
+++ b/SENTRY_FLASK_SETUP_COMPLETE.md
@@ -22,7 +22,7 @@ sentry-sdk[flask]==2.33.2
 ### DSN Configuration
 The Sentry DSN has been updated to match your provided configuration:
 ```
-https://5deb7c885560c5bed065966a8c341727@o4509734387056640.ingest.us.sentry.io/4509741831028736
+<YOUR_SENTRY_DSN>
 ```
 
 ### Flask Integration


### PR DESCRIPTION
## Summary
- remove real Sentry auth token and DSN from setup docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886a73941a08321a31d9599240ff2be