### PR TITLE
docs: focus initial release on air duct sizer

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,8 @@ Welcome to SizeWise Suite, a comprehensive modular HVAC engineering and estimati
 
 SizeWise Suite is an **offline-first**, **modular platform** that unifies duct sizing, vent design, and cost estimating in a single workspace. Built with modern web technologies, it provides:
 
+> **First Offline Release**: Version 1 ships with the **Air Duct Sizer** module only. Additional calculators will be introduced in future updates.
+
 - **Standards Compliance**: Full compliance with SMACNA, NFPA, and ASHRAE standards
 - **Offline-First Design**: Work anywhere, anytime without internet connectivity
 - **Bidirectional Unit Conversion**: Seamless Imperial/SI unit support
@@ -14,20 +16,20 @@ SizeWise Suite is an **offline-first**, **modular platform** that unifies duct s
 
 ## Core Modules
 
-### 🌬️ Air Duct Sizer
+### 🌬️ Air Duct Sizer *(Available Now)*
 Calculate optimal duct sizes for HVAC systems with SMACNA compliance checking, friction loss analysis, and velocity validation.
 
-### 🔥 Grease Duct Sizer *(Coming Soon)*
-Design grease exhaust systems with NFPA 96 compliance and fire safety considerations.
+### 🔥 Grease Duct Sizer *(Planned)*
+Design grease exhaust systems with NFPA 96 compliance and fire safety considerations. This module is scheduled for a future update.
 
-### 🚗 Engine Exhaust Sizer *(Coming Soon)*
-Size engine exhaust systems for parking garages and mechanical rooms.
+### 🚗 Engine Exhaust Sizer *(Planned)*
+Size engine exhaust systems for parking garages and mechanical rooms. This module will be introduced in a later release.
 
-### 🔥 Boiler Vent Sizer *(Coming Soon)*
-Calculate boiler vent requirements with code compliance checking.
+### 🔥 Boiler Vent Sizer *(Planned)*
+Calculate boiler vent requirements with code compliance checking. This module is part of our future roadmap.
 
-### 💰 Estimating App *(Coming Soon)*
-Generate accurate cost estimates for HVAC projects with material and labor calculations.
+### 💰 Estimating App *(Planned)*
+Generate accurate cost estimates for HVAC projects with material and labor calculations. Planned for a future release.
 
 ## Key Features
 

--- a/docs/stakeholder/executive-summary.md
+++ b/docs/stakeholder/executive-summary.md
@@ -23,23 +23,22 @@ The SizeWise Suite Phase 1 implementation has been **successfully completed** on
 
 ### **💰 Revenue-Ready Three-Tier Business Model**
 
-#### **🆓 Free Tier - Market Entry**
 - **Core HVAC Functionality**: Air duct sizing with SMACNA compliance
+- **Initial Release Scope**: Version 1 ships with the Air Duct Sizer only; additional calculators will arrive in future updates.
 - **Basic Project Management**: Limited projects and segments
 - **Standards Access**: Essential SMACNA standards
 - **Target Market**: Individual engineers, students, small firms
 - **Business Value**: Lead generation and market penetration
 
-#### **💼 Pro Tier - Professional Market**
-- **Advanced HVAC Tools**: Boiler vent, grease duct, general ventilation, equipment selection
+- **Advanced HVAC Tools** *(planned)*: Boiler vent, grease duct, general ventilation, equipment selection
 - **Enhanced Project Management**: Unlimited projects, templates, enhanced metadata
 - **Full Standards Suite**: Complete SMACNA, ASHRAE standards with cloud updates
 - **Professional Features**: Enhanced PDF processing, full CAD tools, cloud sync
 - **Target Market**: Professional engineers, mid-size firms
 - **Business Value**: Primary revenue driver with recurring subscriptions
 
-#### **🏢 Enterprise Tier - Corporate Market**
-- **Complete HVAC Suite**: All professional features plus custom standards and templates
+-#### **🏢 Enterprise Tier - Corporate Market**
+- **Complete HVAC Suite** *(future roadmap)*: All professional features plus custom standards and templates
 - **Advanced Collaboration**: Team collaboration, advanced RBAC, real-time collaboration
 - **Enterprise Security**: SSO integration, comprehensive audit logs, compliance certifications
 - **Premium Support**: Priority phone support, custom training, SLA-based updates

--- a/docs/stakeholder/final-implementation-summary.md
+++ b/docs/stakeholder/final-implementation-summary.md
@@ -92,12 +92,13 @@ The SizeWise Suite Phase 1 implementation has been **successfully completed** wi
 
 #### **Free Tier - Market Entry** (Lead Generation)
 - Core HVAC functionality with SMACNA compliance
+- **Initial Release Scope**: Version 1 includes only the Air Duct Sizer module. Additional calculators are planned for future updates.
 - Basic project management (3 projects, 10 segments each)
 - Essential standards access
 - Professional PDF import capabilities
 
 #### **Pro Tier - Primary Revenue** ($49-99/month)
-- Advanced HVAC tools (boiler vent, grease duct, general ventilation)
+- Advanced HVAC tools *(planned)* (boiler vent, grease duct, general ventilation)
 - Unlimited projects with enhanced templates
 - Complete standards suite (SMACNA, ASHRAE)
 - Cloud sync and enhanced PDF processing

--- a/docs/stakeholder/presentation-materials/feature-demonstration-script.md
+++ b/docs/stakeholder/presentation-materials/feature-demonstration-script.md
@@ -54,8 +54,8 @@ Script: "The Free Tier provides core HVAC functionality to capture market share 
 **Pro Tier Demonstration**
 ```
 Action: Switch to Pro Tier (demonstrate tier switching)
-Show:
-- Advanced HVAC tools (boiler vent, grease duct sizing)
+- Show:
+- Advanced HVAC tools *(planned)* (boiler vent, grease duct sizing)
 - Unlimited projects and enhanced templates
 - Full standards suite (SMACNA, ASHRAE)
 - Enhanced PDF processing and CAD tools

--- a/docs/user-guide/air-duct-sizer.md
+++ b/docs/user-guide/air-duct-sizer.md
@@ -4,6 +4,8 @@ _Last updated: 2025-07-13_
 
 ---
 
+> **Release Note:** The first offline version of SizeWise Suite includes only the Air Duct Sizer. Additional calculators are planned for future updates.
+
 ## 1. Vision and Strategic Purpose
 
 The Air Duct Sizer is the centerpiece HVAC engineering tool within the SizeWise Suite, designed for both everyday field professionals and advanced consultants. Its mission is to replace static, error-prone spreadsheets and legacy “ductulator” calculators with an interactive, code-compliant platform that *actually models* real ductwork systems—start to finish.

--- a/docs/user-guide/feature-limitations.md
+++ b/docs/user-guide/feature-limitations.md
@@ -2,6 +2,8 @@
 
 **Understanding tier restrictions and how to work within them**
 
+> **Note:** The first offline release includes only the Air Duct Sizer module. Boiler vent, grease duct, and other calculators will be added later.
+
 ---
 
 ## 🆓 Free Tier Limitations

--- a/docs/user-guide/tier-features-overview.md
+++ b/docs/user-guide/tier-features-overview.md
@@ -56,8 +56,8 @@
 - **Cloud Storage**: Automatic backup and sync across devices
 - **Multi-Device Access**: Work from desktop, laptop, or tablet
 
-### Enhanced HVAC Tools
-- **All HVAC Calculators**: Air ducts, boiler vents, grease ducts, general ventilation
+-### Enhanced HVAC Tools
+- **All HVAC Calculators** *(future)*: Air ducts today, with boiler vents, grease ducts, and general ventilation planned for later releases
 - **Equipment Selection**: Comprehensive equipment databases
 - **Advanced 3D Rendering**: High-quality 3D visualization with materials
 - **Full Standards Access**: Complete SMACNA, ASHRAE, and regional standards
@@ -77,7 +77,7 @@
 ### What's Included
 ✅ **Everything in Free tier**  
 ✅ Unlimited projects and segments  
-✅ All HVAC calculation tools  
+✅ All HVAC calculation tools *(current + planned)*
 ✅ High-resolution exports (no watermark)  
 ✅ Cloud storage and sync  
 ✅ Multi-device access  

--- a/docs/user-guide/upgrade-guide.md
+++ b/docs/user-guide/upgrade-guide.md
@@ -15,7 +15,7 @@
 - ✅ **Professional Exports**: High-resolution PDFs without watermarks
 - ✅ **Cloud Backup**: Never lose your work again
 - ✅ **Multi-Device Access**: Work from anywhere
-- ✅ **All HVAC Tools**: Boiler vents, grease ducts, equipment selection
+- ✅ **All HVAC Tools** *(future)*: Boiler vents, grease ducts, equipment selection (planned for later versions)
 
 **ROI Calculator:**
 - Save 2+ hours per week with unlimited projects


### PR DESCRIPTION
## Summary
- clarify that only the Air Duct Sizer ships in the first offline release
- mark other calculators as planned in index and stakeholder docs
- update user guides to note future HVAC tools

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: missing requests, structlog, flask)*

------
https://chatgpt.com/codex/tasks/task_e_6886a7349e008321bc2fc92976adbd5b