### PR TITLE
docs: organize documentation categories

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# 🗂️ SizeWise Suite Documentation Index
+
+This file organizes the main documentation categories. Use it as your starting point when navigating the docs folder.
+
+## UI Components
+- [Air Duct Sizer UI Components](developer-guide/air-duct-sizer-guide/ui-components.md) – Panels, property fields, and accessibility details.
+
+## Implementation Details
+- [Development Setup](architecture/development-setup.md)
+- [System Architecture](architecture/system-architecture.md)
+- Additional implementation information can be found in the rest of the [architecture](architecture/) documents and the [developer guides](developer-guide/).
+
+## Core Functions and Workflows
+- [Air Duct Sizer User Guide](user-guide/air-duct-sizer.md)
+- [User Stories & Flows](developer-guide/air-duct-sizer-guide/user-stories-flows.md)
+- More step‑by‑step guides live in the [user-guide](user-guide/) directory.

--- a/docs/developer-guide/air-duct-sizer-guide/air-duct-sizer.md
+++ b/docs/developer-guide/air-duct-sizer-guide/air-duct-sizer.md
@@ -1,6 +1,6 @@
 # 🏗️ Air Duct Sizer – Product Overview & Vision
 
-_See docs/README.md for documentation map and update rules._
+_See [docs/README.md](../../README.md) for documentation map and update rules._
 
 _Last updated: 2025-07-13_
 
@@ -100,4 +100,4 @@ _All warnings and auto-sizing recommendations reference these standards (in “E
 
 ---
 
-*This document is your master reference for what the Air Duct Sizer is, who it’s for, what it can/can’t do, and how to keep the boundaries clear as you add new features. For everything else, see the docs listed in README.md!*
+*This document is your master reference for what the Air Duct Sizer is, who it’s for, what it can/can’t do, and how to keep the boundaries clear as you add new features. For everything else, see the docs listed in [README.md](../../README.md)!*

--- a/docs/developer-guide/air-duct-sizer-guide/canvas-drawing.md
+++ b/docs/developer-guide/air-duct-sizer-guide/canvas-drawing.md
@@ -1,6 +1,6 @@
 # 🎨 Canvas Drawing – Interactive Layout & Drawing Behavior
 
-_See docs/README.md for the documentation map and update rules._
+_See [docs/README.md](../../README.md) for the documentation map and update rules._
 
 _Last updated: 2025-07-13_
 
@@ -95,4 +95,4 @@ It’s designed to be user-friendly for both beginners and professionals, suppor
 ---
 
 *This document is your master reference for canvas interaction and drawing behavior.  
-For sidebar fields, calculation rules, or export logic, see the linked markdowns in README.md!*
+For sidebar fields, calculation rules, or export logic, see the linked markdowns in [README.md](../../README.md)!*

--- a/docs/developer-guide/air-duct-sizer-guide/data-models-schemas.md
+++ b/docs/developer-guide/air-duct-sizer-guide/data-models-schemas.md
@@ -1,6 +1,6 @@
 # 📦 Data Models & Schemas – Fields, Types, and JSON
 
-_See docs/README.md for documentation map and update rules._
+_See [docs/README.md](../../README.md) for documentation map and update rules._
 
 _Last updated: 2025-07-13_
 

--- a/docs/developer-guide/air-duct-sizer-guide/exports-reports.md
+++ b/docs/developer-guide/air-duct-sizer-guide/exports-reports.md
@@ -1,6 +1,6 @@
 # 📤 Exports & Reports – Output Formats and Tier Rules
 
-_See docs/README.md for documentation map and update rules._
+_See [docs/README.md](../../README.md) for documentation map and update rules._
 
 _Last updated: 2025-07-13_
 

--- a/docs/developer-guide/air-duct-sizer-guide/feature-flags-boundaries.md
+++ b/docs/developer-guide/air-duct-sizer-guide/feature-flags-boundaries.md
@@ -1,6 +1,6 @@
 # 🏷️ Feature Flags & Free/Pro Boundaries
 
-_See docs/README.md for documentation map and update rules._
+_See [docs/README.md](../../README.md) for documentation map and update rules._
 
 _Last updated: 2025-07-13_
 

--- a/docs/developer-guide/air-duct-sizer-guide/logic-validators.md
+++ b/docs/developer-guide/air-duct-sizer-guide/logic-validators.md
@@ -1,6 +1,6 @@
 # 🧮 Logic & Validators – Engineering Calculations and Rules
 
-_See docs/README.md for documentation map and update rules._
+_See [docs/README.md](../../README.md) for documentation map and update rules._
 
 _Last updated: 2025-07-13_
 

--- a/docs/developer-guide/air-duct-sizer-guide/qa-acceptance-criteria.md
+++ b/docs/developer-guide/air-duct-sizer-guide/qa-acceptance-criteria.md
@@ -1,6 +1,6 @@
 # ✅ QA Acceptance Criteria & Test Scenarios
 
-_See docs/README.md for documentation map and update rules._
+_See [docs/README.md](../../README.md) for documentation map and update rules._
 
 _Last updated: 2025-07-13_
 

--- a/docs/developer-guide/air-duct-sizer-guide/ui-components.md
+++ b/docs/developer-guide/air-duct-sizer-guide/ui-components.md
@@ -1,6 +1,6 @@
 # 🖥️ UI Components – Panels, Properties, and Controls
 
-_See docs/README.md for documentation map and update rules._
+_See [docs/README.md](../../README.md) for documentation map and update rules._
 
 _Last updated: 2025-07-13_
 
@@ -120,4 +120,4 @@ You’ll find onboarding wizards, project/room/segment sidebars, tooltips, acces
 ---
 
 *This document is your single source of truth for all UI components, property panels, tooltips, and accessibility requirements.  
-See linked markdowns in README.md for further details!*
+See linked markdowns in [README.md](../../README.md) for further details!*

--- a/docs/developer-guide/air-duct-sizer-guide/user-stories-flows.md
+++ b/docs/developer-guide/air-duct-sizer-guide/user-stories-flows.md
@@ -1,6 +1,6 @@
 # 👤 User Stories & Workflow Flows
 
-_See docs/README.md for documentation map and update rules._
+_See [docs/README.md](../../README.md) for documentation map and update rules._
 
 _Last updated: 2025-07-13_
 


### PR DESCRIPTION
## Summary
- add `docs/README.md` with links to major sections
- link to the docs index from air-duct-sizer docs

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: missing dependencies like requests, structlog, flask)*


------
https://chatgpt.com/codex/tasks/task_e_6886a730d1c083219796f6e3f2799659