### PR TITLE
Apply tier-based rules and disable anonymous auth

### DIFF
--- a/Triggers/auth/providers.json
+++ b/Triggers/auth/providers.json
@@ -1,1 +1,5 @@
-{}
+{
+  "anon-user": {
+    "disabled": true
+  }
+}

--- a/Triggers/data_sources/SizeWiseSpatial/AirDuctProjectData/AirDuctSizer/rules.json
+++ b/Triggers/data_sources/SizeWiseSpatial/AirDuctProjectData/AirDuctSizer/rules.json
@@ -1,0 +1,4 @@
+{
+  "read": "%%user.custom_data.tier != null%%",
+  "write": "%%user.custom_data.tier == 'pro' || %%user.custom_data.tier == 'enterprise'%%"
+}

--- a/Triggers/data_sources/SizeWiseSpatial/AirDuctProjectData/AirDuctSizer/schema.json
+++ b/Triggers/data_sources/SizeWiseSpatial/AirDuctProjectData/AirDuctSizer/schema.json
@@ -1,0 +1,13 @@
+{
+  "title": "Air Duct Sizer Record",
+  "bsonType": "object",
+  "required": ["owner_id", "input", "result"],
+  "properties": {
+    "_id": { "bsonType": "objectId" },
+    "owner_id": { "bsonType": "objectId", "description": "Owner user id" },
+    "input": { "bsonType": "object", "description": "Input parameters" },
+    "result": { "bsonType": "object", "description": "Calculated results" },
+    "created_at": { "bsonType": "date" },
+    "updated_at": { "bsonType": "date" }
+  }
+}


### PR DESCRIPTION
## Summary
- disable anonymous authentication provider
- restrict read/write in AirDuctSizer based on user tier
- define AirDuctSizer validation schema

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: ModuleNotFoundError: flask)*

------
https://chatgpt.com/codex/tasks/task_e_6886a22bd0a4832196c4321895f4504c