### PR TITLE
Potential fix for code scanning alert no. 87: Clear-text logging of sensitive information

### DIFF
--- a/frontend 2/scripts/generate-super-admin.ts
+++ b/frontend 2/scripts/generate-super-admin.ts
@@ -27,7 +27,12 @@ function generateSuperAdminCredentials() {
     console.log('-'.repeat(40));
     console.log(`Username: ${credentials.username}`);
     console.log(`Email:    ${credentials.email}`);
-    console.log(`Password: ${credentials.password}`);
+    if (process.argv.includes('--show-password')) {
+      console.log('⚠️  WARNING: Displaying password in clear text. Do not share or store this output.');
+      console.log(`Password: ${credentials.password}`);
+    } else {
+      console.log('Password: [HIDDEN] (run with --show-password to display)');
+    }
     console.log(`Login URL: ${credentials.loginUrl}`);
     
     console.log('\n👤 USER DETAILS:');


### PR DESCRIPTION
Potential fix for [https://github.com/engryamato/SizeWise_Suite_App/security/code-scanning/87](https://github.com/engryamato/SizeWise_Suite_App/security/code-scanning/87)

To fix the problem, we should prevent the password from being logged in clear text. The best approach is to avoid printing the password to the console by default. If the password must be shown, require an explicit command-line flag (e.g., `--show-password`) to display it, and otherwise print a message instructing the user how to retrieve it securely. This minimizes accidental exposure while still allowing the operator to access the password if needed.

**Steps:**
- Remove or comment out the line that logs the password.
- Optionally, add logic to check for a `--show-password` flag in `process.argv`. Only display the password if this flag is present, and print a warning.
- If the flag is not present, print a message indicating that the password is not shown for security reasons.

**Required changes:**
- Edit the block in `generateSuperAdminCredentials` where the password is logged.
- Add logic to check for the flag at the top of the script or within the function.
- No new imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
