### PR TITLE
Add StatusBar summary toggle

### DIFF
--- a/frontend/app/air-duct-sizer/page.tsx
+++ b/frontend/app/air-duct-sizer/page.tsx
@@ -397,6 +397,8 @@ function AirDuctSizerPage() {
         onZoomIn={handleZoomIn}
         onZoomOut={handleZoomOut}
         onZoomReset={handleZoomReset}
+        summaryOpen={showModelSummary}
+        onSummaryToggle={() => setShowModelSummary(prev => !prev)}
         userName="Demo User"
         projectName="Air Duct Sizer"
         currentBranch="main"
@@ -418,27 +420,6 @@ function AirDuctSizerPage() {
       {/* Priority 6: Bottom Right Corner - Chat & Help */}
       <BottomRightCorner className="fixed bottom-6 right-6 z-50" />
 
-      {/* Model Summary Trigger Button (floating) */}
-      <motion.button
-        type="button"
-        onClick={() => setShowModelSummary(!showModelSummary)}
-        className="fixed top-20 left-4 z-[60] flex items-center space-x-2 px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-lg shadow-lg transition-colors"
-        whileHover={{ scale: 1.05 }}
-        whileTap={{ scale: 0.95 }}
-      >
-        <motion.div
-          animate={{ rotate: isCalculating ? 360 : 0 }}
-          transition={{ duration: 1, repeat: isCalculating ? Infinity : 0, ease: "linear" }}
-        >
-          📊
-        </motion.div>
-        <span className="text-sm font-medium">Model Summary</span>
-        {warnings.filter(w => !w.resolved).length > 0 && (
-          <span className="px-2 py-1 bg-red-500 text-white text-xs rounded-full">
-            {warnings.filter(w => !w.resolved).length}
-          </span>
-        )}
-      </motion.button>
 
       {/* Priority 7: ViewCube 3D Navigation */}
       <ViewCube

--- a/frontend/components/layout/AppShellPresentation.tsx
+++ b/frontend/components/layout/AppShellPresentation.tsx
@@ -213,6 +213,8 @@ export const AppShellPresentation: React.FC<AppShellPresentationProps> = ({
           onZoomIn={() => {}}
           onZoomOut={() => {}}
           onZoomReset={() => {}}
+          summaryOpen={false}
+          onSummaryToggle={() => {}}
           userName={user?.name}
           projectName="Current Project" // This would come from project state
           calculationStatus="idle"

--- a/frontend/components/ui/StatusBar.tsx
+++ b/frontend/components/ui/StatusBar.tsx
@@ -42,6 +42,10 @@ interface StatusBarProps {
   onZoomIn: () => void;
   onZoomOut: () => void;
   onZoomReset: () => void;
+
+  // Model summary
+  summaryOpen: boolean;
+  onSummaryToggle: () => void;
   
   // User and project info
   userName?: string;
@@ -150,6 +154,8 @@ export const StatusBar: React.FC<StatusBarProps> = ({
   onZoomIn,
   onZoomOut,
   onZoomReset,
+  summaryOpen,
+  onSummaryToggle,
   userName,
   projectName,
   currentBranch,
@@ -310,12 +316,20 @@ export const StatusBar: React.FC<StatusBarProps> = ({
             tooltip="Toggle grid (G)"
           />
           
-          <ToggleButton
+        <ToggleButton
             icon={<Settings className="w-4 h-4" />}
             label="Snap"
             isActive={snapEnabled}
             onClick={onSnapToggle}
             tooltip="Toggle snap to grid (Shift+G)"
+          />
+
+          <ToggleButton
+            icon={<Info className="w-4 h-4" />}
+            label="Summary"
+            isActive={summaryOpen}
+            onClick={onSummaryToggle}
+            tooltip="Toggle model summary (S)"
           />
           
           <div className="flex items-center space-x-1 px-3 py-1 bg-neutral-500/10 rounded-lg border border-neutral-500/20">

--- a/frontend/components/ui/__tests__/StatusBar.test.tsx
+++ b/frontend/components/ui/__tests__/StatusBar.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { StatusBar } from '../StatusBar';
+
+/** Minimal props for StatusBar */
+const baseProps = {
+  isOnline: true,
+  isConnectedToServer: true,
+  saveStatus: 'saved' as const,
+  gridEnabled: true,
+  snapEnabled: true,
+  zoomLevel: 1,
+  onGridToggle: jest.fn(),
+  onSnapToggle: jest.fn(),
+  onZoomIn: jest.fn(),
+  onZoomOut: jest.fn(),
+  onZoomReset: jest.fn(),
+  summaryOpen: false,
+  onSummaryToggle: jest.fn(),
+};
+
+describe('StatusBar Summary Button', () => {
+  test('renders Summary toggle and fires callback', () => {
+    render(<StatusBar {...baseProps} />);
+    const summaryButton = screen.getByRole('button', { name: /summary/i });
+    expect(summaryButton).toBeInTheDocument();
+    fireEvent.click(summaryButton);
+    expect(baseProps.onSummaryToggle).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add summary toggle props to StatusBar
- connect StatusBar summary toggle in air-duct-sizer
- remove old floating model summary button
- keep StatusBar working in AppShellPresentation
- test new StatusBar summary toggle

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b9a5ac3d48321b6d2ef9831b06d7f