### PR TITLE
Add square throat option for elbows

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ SizeWise Suite is specifically crafted for:
 - **Plugin-Ready Architecture**: Highly scalable with minimal integration overhead
 - **Glassmorphism UI**: Beautiful glass-effect components with backdrop blur and animations
 - **3D Workspace**: Interactive Three.js-based 3D environment for duct system design
+- **Rectangular Elbow Throat Options**: Set `throatType` to `radius` (default) or `square` for 3D elbows
 - **PDF Integration**: Import and overlay PDF plans in the 3D workspace
 - **Modern Architecture**: Next.js with TypeScript for type safety and performance
 

--- a/frontend/components/3d/Canvas3D.tsx
+++ b/frontend/components/3d/Canvas3D.tsx
@@ -13,6 +13,7 @@ import {
   Box
 } from '@react-three/drei';
 import { Vector3, Vector2, Raycaster, Quaternion, Euler } from 'three';
+import { createRectangularElbowGeometry } from '@/utils/geometry';
 import { useCameraController } from '@/lib/hooks/useCameraController';
 import { useUIStore } from '@/stores/ui-store';
 import { motion } from 'framer-motion';
@@ -104,6 +105,11 @@ interface TransitionFitting extends DuctFitting {
 interface ElbowFitting extends DuctFitting {
   type: 'elbow';
   elbowType: 'rectangular' | 'round';
+  /**
+   * Throat type for rectangular elbows. Defaults to 'radius'.
+   * 'square' produces a sharp L-shaped profile.
+   */
+  throatType?: 'radius' | 'square';
   angle: 30 | 45 | 90; // Restricted angles for snapping
   centerlineRadius: number; // Based on SMACNA guidelines
 }
@@ -470,7 +476,8 @@ class FittingGenerator {
   static generateElbow(
     segment1: DuctSegment,
     segment2: DuctSegment,
-    connectionPoint: Vector3
+    connectionPoint: Vector3,
+    throatType: 'radius' | 'square' = 'radius'
   ): ElbowFitting {
     const angle = ConnectivityAnalyzer.calculateAngle(segment1, segment2);
     const snappedAngle = SMACNAStandards.snapAngle(angle);
@@ -492,6 +499,7 @@ class FittingGenerator {
       id: `elbow-${Date.now()}`,
       type: 'elbow',
       elbowType: segment1.shape,
+      throatType,
       angle: snappedAngle,
       centerlineRadius,
       position: connectionPoint,
@@ -735,6 +743,19 @@ const ElbowMesh: React.FC<{
 
   const elbowDimensions = { ductSize, ductWidth, ductHeight };
 
+  const rectElbowGeometry = useMemo(() => {
+    if (fitting.inlet.shape === 'rectangular') {
+      return createRectangularElbowGeometry(
+        elbowDimensions.ductWidth,
+        elbowDimensions.ductHeight,
+        fitting.centerlineRadius,
+        fitting.angle,
+        fitting.throatType ?? 'radius'
+      );
+    }
+    return null;
+  }, [fitting, elbowDimensions]);
+
   const getColor = () => {
     if (isSelected) return '#3b82f6'; // Blue when selected
     if (hovered) return '#6366f1'; // Indigo when hovered
@@ -755,8 +776,8 @@ const ElbowMesh: React.FC<{
         // Round elbow - torus segment with actual diameter
         <torusGeometry args={[fitting.centerlineRadius, elbowDimensions.ductSize / 2, 8, 16, (fitting.angle * Math.PI) / 180]} />
       ) : (
-        // Rectangular elbow - box geometry with actual width and height
-        <boxGeometry args={[elbowDimensions.ductWidth, elbowDimensions.ductHeight, fitting.centerlineRadius * 0.5]} />
+        // Rectangular elbow - generated geometry based on throat type
+        rectElbowGeometry && <primitive object={rectElbowGeometry} />
       )}
       <meshStandardMaterial
         color={getColor()}

--- a/frontend/tests/unit/geometry.test.ts
+++ b/frontend/tests/unit/geometry.test.ts
@@ -1,0 +1,22 @@
+import { createRectangularElbowGeometry } from '../../utils/geometry';
+import { BufferGeometry } from 'three';
+
+describe('createRectangularElbowGeometry', () => {
+  test('creates radial throat geometry within expected bounds', () => {
+    const geom = createRectangularElbowGeometry(2, 2, 5, 90, 'radius');
+    geom.computeBoundingBox();
+    const bbox = geom.boundingBox!;
+    expect(Math.round(bbox.max.x)).toBe(5);
+    expect(Math.round(bbox.max.z)).toBe(5);
+    expect(geom).toBeInstanceOf(BufferGeometry);
+  });
+
+  test('creates square throat geometry with corner', () => {
+    const geom = createRectangularElbowGeometry(2, 2, 5, 90, 'square');
+    geom.computeBoundingBox();
+    const bbox = geom.boundingBox!;
+    expect(Math.round(bbox.max.x)).toBe(5);
+    expect(Math.round(bbox.max.z)).toBe(5);
+  });
+});
+

--- a/frontend/utils/geometry.ts
+++ b/frontend/utils/geometry.ts
@@ -1,0 +1,63 @@
+import { Curve, Vector3, Shape, ExtrudeGeometry } from 'three';
+
+/** Curve representing a smooth radius elbow path */
+class RadialElbowCurve extends Curve<Vector3> {
+  constructor(private radius: number, private angle: number) {
+    super();
+  }
+
+  override getPoint(t: number, target = new Vector3()): Vector3 {
+    const theta = this.angle * t;
+    target.set(
+      this.radius * Math.sin(theta),
+      0,
+      this.radius * (1 - Math.cos(theta))
+    );
+    return target;
+  }
+}
+
+/** Curve representing a square-throat elbow path */
+class SquareElbowCurve extends Curve<Vector3> {
+  constructor(private length: number) {
+    super();
+  }
+
+  override getPoint(t: number, target = new Vector3()): Vector3 {
+    if (t < 0.5) {
+      return target.set(0, 0, this.length * 2 * t);
+    }
+    return target.set(this.length * 2 * (t - 0.5), 0, this.length);
+  }
+}
+
+/**
+ * Create a rectangular elbow geometry.
+ * @param width duct width
+ * @param height duct height
+ * @param radius centerline radius
+ * @param angle elbow angle in degrees
+ * @param throatType throat style ('radius' | 'square')
+ */
+export function createRectangularElbowGeometry(
+  width: number,
+  height: number,
+  radius: number,
+  angle: number,
+  throatType: 'radius' | 'square' = 'radius'
+): ExtrudeGeometry {
+  const shape = new Shape();
+  shape.moveTo(-width / 2, -height / 2);
+  shape.lineTo(width / 2, -height / 2);
+  shape.lineTo(width / 2, height / 2);
+  shape.lineTo(-width / 2, height / 2);
+  shape.closePath();
+
+  const path =
+    throatType === 'square'
+      ? new SquareElbowCurve(radius)
+      : new RadialElbowCurve(radius, (angle * Math.PI) / 180);
+
+  return new ExtrudeGeometry(shape, { steps: 20, extrudePath: path });
+}
+


### PR DESCRIPTION
## Summary
- add `throatType` field to `ElbowFitting`
- generate elbows with optional square or radius throats
- implement `createRectangularElbowGeometry` utility
- render rectangular elbows using new geometry helper
- document the new option in README
- add unit tests for geometry

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b9c7b11a08321a1939b41e92a2cbd