### PR TITLE
Update connection point creation with id and status

### DIFF
--- a/frontend/components/3d/Canvas3D.tsx
+++ b/frontend/components/3d/Canvas3D.tsx
@@ -554,12 +554,14 @@ class FittingGenerator {
     direction: Vector3
   ): ConnectionPoint {
     return {
+      id: `${segment.id}-cp-${Date.now()}`,
       position,
       direction,
       shape: segment.shape,
       width: segment.width,
       height: segment.height,
-      diameter: segment.diameter
+      diameter: segment.diameter,
+      status: 'available'
     };
   }
 }


### PR DESCRIPTION
## Summary
- create unique connection point id and mark status as available within `FittingGenerator.createConnectionPoint`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b9148b5708321a603e63d2091f235