### PR TITLE
Add generated ID to connection point creation

### DIFF
--- a/frontend/components/3d/Canvas3D.tsx
+++ b/frontend/components/3d/Canvas3D.tsx
@@ -553,7 +553,10 @@ class FittingGenerator {
     position: Vector3,
     direction: Vector3
   ): ConnectionPoint {
+    const generatedId = `${segment.id}-fit-${Date.now()}`;
     return {
+      id: generatedId,
+      status: 'available',
       position,
       direction,
       shape: segment.shape,


### PR DESCRIPTION
## Description
- include an id and default status when creating fitting connection points
- keep Canvas3D fitting generation compatible with new fields

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b8bd99ebc8321ae7217b247a91fca